### PR TITLE
Implementar filtros para el historial de prestamos por estado y periodo

### DIFF
--- a/src/controllers/loans.controller.ts
+++ b/src/controllers/loans.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param, Patch, UseGuards, Query } from '@nestjs/common';
 import { Put, Delete } from '@nestjs/common';
 import { LoansService } from '../services/loans.service';
 import { CreateLoanDto } from '../dto/loans/create-loan.dto';
@@ -7,7 +7,8 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '../entities/user.entity';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { LoanStatus } from '../entities/loan.entity';
+import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger';
 
 @ApiTags('loans')
 @ApiBearerAuth()
@@ -49,8 +50,16 @@ export class LoansController {
 
   @Get('student/:userId')
   @Roles(UserRole.ESTUDIANTE, UserRole.ADMINISTRATIVO, UserRole.BIBLIOTECARIO)
-  findByStudent(@Param('userId') userId: string) {
-    return this.loansService.findByStudent(+userId);
+  @ApiQuery({ name: 'status', required: false, enum: LoanStatus })
+  @ApiQuery({ name: 'startDate', required: false, type: String, description: 'YYYY-MM-DD' })
+  @ApiQuery({ name: 'endDate', required: false, type: String, description: 'YYYY-MM-DD' })
+  findByStudent(
+    @Param('userId') userId: string,
+    @Query('status') status?: LoanStatus,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.loansService.findByStudent(+userId, status, startDate, endDate);
   }
 
   @Patch(':id/return')

--- a/src/services/loans.service.ts
+++ b/src/services/loans.service.ts
@@ -135,14 +135,28 @@ export class LoansService {
     });
   }
 
-  async findByStudent(estudianteId: number): Promise<Loan[]> {
-    return this.loanRepository.find({
-      where: { estudianteId },
-      relations: ['libro', 'estudiante', 'estudiante.user', 'multa'],
-      order: {
-        fechaPrestamo: 'DESC',
-      },
-    });
+  async findByStudent(estudianteId: number, status?: LoanStatus, startDate?: string, endDate?: string): Promise<Loan[]> {
+    const query = this.loanRepository.createQueryBuilder('loan')
+      .leftJoinAndSelect('loan.libro', 'libro')
+      .leftJoinAndSelect('loan.estudiante', 'estudiante')
+      .leftJoinAndSelect('estudiante.user', 'user')
+      .leftJoinAndSelect('loan.multa', 'multa')
+      .where('loan.estudianteId = :estudianteId', { estudianteId });
+
+    if (status) {
+      query.andWhere('loan.estado = :status', { status });
+    }
+
+    if (startDate && endDate) {
+      query.andWhere('loan.fechaPrestamo BETWEEN :startDate AND :endDate', { 
+        startDate, 
+        endDate 
+      });
+    }
+
+    query.orderBy('loan.fechaPrestamo', 'DESC');
+
+    return query.getMany();
   }
 
   async findPendingFinesByUser(estudianteId: number): Promise<Fine[]> {


### PR DESCRIPTION
Se habilitaron capacidades de filtrado dinámico en el historial de préstamos para estudiantes. Ahora es posible consultar registros específicos filtrando por estado (ACTIVO, DEVUELTO, etc.) y por periodos de fechas definidos, mejorando la gestión de la información académica y bibliográfica del usuario
Closes #53 