### PR TITLE
Añadir registros de auditoria para cambios de estado del usuario

### DIFF
--- a/src/controllers/users.controller.ts
+++ b/src/controllers/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, HttpCode, HttpStatus, UsePipes, ValidationPipe, Get, Param, ParseIntPipe, Put, Patch } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, HttpStatus, UsePipes, ValidationPipe, Get, Param, ParseIntPipe, Put, Patch, Req } from '@nestjs/common';
 import { UsersService } from '../services/users.service';
 import { RegisterUserDto } from '../dto/users/register-user.dto';
 import { UpdateUserDto, UpdateUserStatusDto } from '../dto/users/update-user.dto';
@@ -48,7 +48,9 @@ export class UsersController {
   async updateStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() updateStatusDto: UpdateUserStatusDto,
+    @Req() req: any,
   ) {
-    return this.usersService.updateStatus(id, updateStatusDto);
+    const adminId = req.user.userId || req.user.id;
+    return this.usersService.updateStatus(id, updateStatusDto, adminId);
   }
 }

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -43,12 +43,11 @@ export class User {
   })
   rol!: UserRole;
 
-  @Column({
-    type: 'enum',
-    enum: UserStatus,
-    default: UserStatus.ACTIVO,
-  })
+  @Column({ name: 'estado', type: 'enum', enum: UserStatus, default: UserStatus.ACTIVO })
   estado!: UserStatus;
+
+  @Column({ name: 'actualizado_por_id', type: 'int', nullable: true })
+  actualizadoPorId!: number | null;
 
   @CreateDateColumn({ name: 'creado_en' })
   creadoEn!: Date;

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -163,7 +163,7 @@ export class UsersService {
     };
   }
 
-  async updateStatus(id: number, updateStatusDto: UpdateUserStatusDto) {
+  async updateStatus(id: number, updateStatusDto: UpdateUserStatusDto, adminId: number) {
     const user = await this.usersRepository.findOne({ where: { id } });
     
     if (!user) {
@@ -171,6 +171,7 @@ export class UsersService {
     }
 
     user.estado = updateStatusDto.estado as UserStatus;
+    user.actualizadoPorId = adminId;
     await this.usersRepository.save(user);
 
     return {
@@ -179,6 +180,7 @@ export class UsersService {
       correoInstitucional: user.correoInstitucional,
       rol: user.rol,
       estado: user.estado,
+      actualizadoPorId: user.actualizadoPorId,
     };
   }
 


### PR DESCRIPTION
Se implementó un sistema de auditoría para el cambio de estado de los usuarios. Ahora, cada vez que un administrador activa, bloquea o inactiva una cuenta, el sistema registra el ID del responsable en la base de datos, garantizando trazabilidad total sobre las acciones administrativas
Closes #55 